### PR TITLE
feat(nginx): support proxy cache.

### DIFF
--- a/default.conf
+++ b/default.conf
@@ -1,7 +1,9 @@
+proxy_cache_path /data keys_zone=cache_zone:10m;
+
 server {
-  listen 80 default_server;
-  listen [::]:80 default_server;
-  server_name ${NGINX_HOST};
+  # Internal image resizing server.
+  server_name localhost;
+  listen 8888;
 
   location ~ ^/([0-9]+)/(.*)$ {
     set $width $1;
@@ -11,6 +13,25 @@ server {
     image_filter resize $width -;
     image_filter_buffer 100M;
     image_filter_jpeg_quality ${JPG_QUALITY};
+  }
+}
+
+
+server {
+  listen 80 default_server;
+  listen [::]:80 default_server;
+  server_name ${NGINX_HOST};
+
+  location ~ ^/([0-9]+)/(.*)$ {
+    set $width $1;
+    set $path $2;
+    rewrite ^ /$path break;
+    proxy_pass http://127.0.0.1:8888/$width/$path;
+    proxy_cache cache_zone;
+    proxy_cache_key $uri;
+    proxy_cache_valid 200 302 24h;
+    proxy_cache_valid 404 1m;
+    # expire time for browser
     expires ${EXPIRE_TIME};
   }
 }


### PR DESCRIPTION
fix #7 

# Benchmark

without cache

```
$ echo "GET http://localhost:8002/310/test/26946324088_5b3f0b1464_o.png" | vegeta attack -rate=100 -connections=1 -duration=1s | tee results.bin | vegeta report
Requests      [total, rate]            100, 101.01
Duration      [total, attack, wait]    8.258454731s, 989.999ms, 7.268455731s
Latencies     [mean, 50, 95, 99, max]  3.937031678s, 4.079690985s, 6.958110121s, 7.205018428s, 7.268455731s
Bytes In      [total, mean]            4455500, 44555.00
Bytes Out     [total, mean]            0, 0.00
Success       [ratio]                  100.00%
Status Codes  [code:count]             200:100
Error Set:
```

with cache

```
$ echo "GET http://localhost:8002/310/test/26946324088_5b3f0b1464_o.png" | vegeta attack -rate=100 -connections=1 -duration=1s | tee results.bin | vegeta report
Requests      [total, rate]            100, 101.01
Duration      [total, attack, wait]    993.312255ms, 989.998ms, 3.314255ms
Latencies     [mean, 50, 95, 99, max]  3.717219ms, 3.05486ms, 8.891027ms, 12.488937ms, 12.520428ms
Bytes In      [total, mean]            4455500, 44555.00
Bytes Out     [total, mean]            0, 0.00
Success       [ratio]                  100.00%
Status Codes  [code:count]             200:100
Error Set:
```